### PR TITLE
Add an image prune to daily ansible

### DIFF
--- a/playbooks/start-collector.yaml
+++ b/playbooks/start-collector.yaml
@@ -62,6 +62,9 @@
         append: yes
         state: present
 
+    - name: Clean dangling images
+      shell: docker image prune -f
+
     - set_fact: collector_version="{{ lookup('env','COLLECTOR_VERSION') }}"
 
     - name: Clone the collector repo


### PR DESCRIPTION
The collector images are taking a lot space in the disk, so we would want to clean the unused images in a daily routine using `docker image prune` using our daily ansible.