### PR TITLE
Update GolangCI-lint to v1.60.1

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59
+          version: v1.60
           args: --timeout 10m0s
 
       - name: Checkmake

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -116,6 +116,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.59.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.60.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ GIT_COMMIT=$(shell scripts/create-version-files.sh)
 GIT_RELEASE=$(shell scripts/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell scripts/get-git-previous-release.sh)
 BASH_SCRIPTS=$(shell find . -name "*.sh" -not -path "./.git/*")
-GOLANGCI_VERSION=v1.59.1
+GOLANGCI_VERSION=v1.60.1
 LINKER_TNF_RELEASE_FLAGS=-X github.com/redhat-best-practices-for-k8s/certsuite/certsuite.GitCommit=${GIT_COMMIT}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/redhat-best-practices-for-k8s/certsuite/certsuite.GitRelease=${GIT_RELEASE}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/redhat-best-practices-for-k8s/certsuite/certsuite.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2362