### PR TITLE
Add Collector's sanity check workflow

### DIFF
--- a/.github/workflows/curl-collector.yaml
+++ b/.github/workflows/curl-collector.yaml
@@ -16,3 +16,11 @@ jobs:
       - name: 'Perform a GET request to collector'
         run: |
           curl $ENDPOINT || exit $?
+
+      - name: Send chat msg to dev team if collector's GET request failed.
+        if: ${{ steps.collector_sanity_check.outcome == 'failure' }}
+        uses: ./certsuite/.github/actions/slack-webhook-sender
+        with:
+          working_directory: certsuite
+          message: 'Collector GET request has failed'
+          slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -274,16 +274,16 @@ jobs:
             --label-filter="${SMOKE_TESTS_LABELS_FILTER}"
 
       - name: Run sanity check on collector
-        uses: ./collector/.github/actions/run-sanity-check
+        uses: ./.github/actions/run-sanity-check
         with:
           collector_username: ${COLLECTOR_CIUSER}
           collector_password: ${COLLECTOR_CIPASSWORD}
         continue-on-error: true
 
-      # - name: Send chat msg to dev team if collector's sanity check failed.
-      #   if: ${{ steps.collector_sanity_check.outcome == 'failure' }}
-      #   uses: ./certsuite/.github/actions/slack-webhook-sender
-      #   with:
-      #     working_directory: certsuite
-      #     message: 'Collector sanity check has failed'
-      #     slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'
+        # - name: Send chat msg to dev team if collector's sanity check failed.
+        #   if: ${{ steps.collector_sanity_check.outcome == 'failure' }}
+        #   uses: ./certsuite/.github/actions/slack-webhook-sender
+        #   with:
+        #     working_directory: certsuite
+        #     message: 'Collector sanity check has failed'
+        #     slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -15,6 +15,8 @@ env:
   COLLECTOR_IMAGE_NAME_LEGACY: testnetworkfunction/collector
   CERTSUITE_IMAGE_NAME: redhat-best-practices-for-k8s/certsuite
   CERTSUITE_IMAGE_TAG: latest
+  CERTSUITE_CONFIG_DIR: /tmp/certsuite/config
+  CERTSUITE_OUTPUT_DIR: /tmp/certsuite/output
 jobs:
   lint:
     name: Run Linter and Vet
@@ -276,7 +278,7 @@ jobs:
 
       # - name: Send chat msg to dev team if collector's sanity check failed.
       #   if: ${{ steps.collector_sanity_check.outcome == 'failure' }}
-      #   uses: ./.github/actions/slack-webhook-sender
+      #   uses: ./certsuite/.github/actions/slack-webhook-sender
       #   with:
       #     working_directory: certsuite
       #     message: 'Collector sanity check has failed'

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -164,3 +164,118 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'redhat-best-practices-for-k8s' }}
         with:
           ssh-private-key: ${{ secrets.COLLECTOR_KEYPAIR }}
+
+  sanity-check:
+    name: Run Collector's sanity check
+    runs-on: ubuntu-22.04
+    env:
+      SHELL: /bin/bash
+      KUBECONFIG: '/home/runner/.kube/config'
+      PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
+
+    steps:
+      - name: Write temporary docker file
+        run: |
+          mkdir -p /home/runner/.docker
+          touch ${PFLT_DOCKERCONFIG}
+          echo '{ "auths": {} }' >> ${PFLT_DOCKERCONFIG}
+
+      # needed by depends-on-action
+      - name: Set up Go 1.23
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: 1.23.1
+
+      # Perform smoke tests using a Certsuite container.
+      - name: Check out code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Check out `certsuite`
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: redhat-best-practices-for-k8s/certsuite
+          path: certsuite
+
+      - name: Setup partner cluster
+        uses: ./.github/actions/setup-partner-cluster
+        with:
+          working_directory: certsuite
+          make-command: 'install'
+
+      - name: Extract dependent Pull Requests
+        uses: depends-on/depends-on-action@9e8a61fce18b15281e831f1bba0e14c71d1e1f46 # main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Clean up unused container image layers. We need to filter out a possible error return code
+      # from docker with "|| true" as some images might still be used by running kind containers and
+      # will not be removed.
+      - name: Remove unnamed/dangling container images to save space. Show disk space before and after removing them.
+        run: |
+          df -h
+          docker rmi $(docker images -f "dangling=true" -q) || true
+          df -h
+
+      - name: Create required Certsuite config files and directories
+        run: |
+          mkdir -p $CERTSUITE_CONFIG_DIR $CERTSUITE_OUTPUT_DIR
+          cp /home/runner/.kube/config $CERTSUITE_CONFIG_DIR/kubeconfig
+          cp /home/runner/.docker/config $CERTSUITE_CONFIG_DIR/dockerconfig
+          cp config/*.yml $CERTSUITE_CONFIG_DIR
+        shell: bash
+
+      - name: Get Collector's CI credentials
+        run: |
+          echo "collector_ciuser=ciuser_${{ github.run_id }}" >> $GITHUB_OUTPUT
+          echo "collector_cipassword=cipassword" >> $GITHUB_OUTPUT
+        id: set_collector_ci_creds
+
+      - name: Update Collector's CI credentials and Print username
+        run: |
+          echo Collector CI username: ${{ steps.set_collector_ci_creds.outputs.collector_ciuser }}
+          echo "COLLECTOR_CIUSER=${{ steps.set_collector_ci_creds.outputs.collector_ciuser }}" >> $GITHUB_ENV
+          echo "COLLECTOR_CIPASSWORD=${{ steps.set_collector_ci_creds.outputs.collector_cipassword }}" >> $GITHUB_ENV
+
+      - name: Ensure COLLECTOR_CIUSER and COLLECTOR_CIPASSWORD are set
+        run: '[[ -n "$COLLECTOR_CIUSER" ]] && [[ -n "$COLLECTOR_CIPASSWORD" ]]'
+
+      - name: Modify Certsuite config with CI collector credentials
+        run: |
+          sed -i\
+            -e '/executedBy/s/""/"CI"/g' \
+            -e '/partnerName/s/""/"${{ env.COLLECTOR_CIUSER }}"/g' \
+            -e '/collectorAppPassword/s/""/"${{ env.COLLECTOR_CIPASSWORD }}"/g' \
+            $CERTSUITE_CONFIG_DIR/certsuite_config.yml
+
+      - name: 'Test: Run Smoke Tests in a Certsuite container with the certsuite command'
+        run: |
+          docker run --rm --network host \
+            -v $CERTSUITE_CONFIG_DIR:/usr/certsuite/config:Z \
+            -v $CERTSUITE_OUTPUT_DIR:/usr/certsuite/output:Z \
+            ${REGISTRY_LOCAL}/${CERTSUITE_IMAGE_NAME}:${CERTSUITE_IMAGE_TAG} \
+            certsuite run \
+            --output-dir=/usr/certsuite/output \
+            --preflight-dockerconfig=/usr/certsuite/config/dockerconfig \
+            --offline-db=/usr/offline-db \
+            --enable-data-collection=true \
+            --log-level=${SMOKE_TESTS_LOG_LEVEL} \
+            --config-file=/usr/certsuite/config/certsuite_config.yml \
+            --kubeconfig=/usr/certsuite/config/kubeconfig \
+            --label-filter="${SMOKE_TESTS_LABELS_FILTER}"
+
+      - name: Run sanity check on collector
+        uses: ./collector/.github/actions/run-sanity-check
+        with:
+          collector_username: ${COLLECTOR_CIUSER}
+          collector_password: ${COLLECTOR_CIPASSWORD}
+        continue-on-error: true
+
+      # - name: Send chat msg to dev team if collector's sanity check failed.
+      #   if: ${{ steps.collector_sanity_check.outcome == 'failure' }}
+      #   uses: ./.github/actions/slack-webhook-sender
+      #   with:
+      #     working_directory: certsuite
+      #     message: 'Collector sanity check has failed'
+      #     slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -280,10 +280,10 @@ jobs:
           collector_password: ${COLLECTOR_CIPASSWORD}
         continue-on-error: true
 
-        # - name: Send chat msg to dev team if collector's sanity check failed.
-        #   if: ${{ steps.collector_sanity_check.outcome == 'failure' }}
-        #   uses: ./certsuite/.github/actions/slack-webhook-sender
-        #   with:
-        #     working_directory: certsuite
-        #     message: 'Collector sanity check has failed'
-        #     slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'
+      - name: Send chat msg to dev team if collector's sanity check failed.
+        if: ${{ steps.collector_sanity_check.outcome == 'failure' }}
+        uses: ./certsuite/.github/actions/slack-webhook-sender
+        with:
+          working_directory: certsuite
+          message: 'Collector sanity check has failed'
+          slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -201,7 +201,7 @@ jobs:
           path: certsuite
 
       - name: Setup partner cluster
-        uses: ./.github/actions/setup-partner-cluster
+        uses: ./certsuite/.github/actions/setup-partner-cluster
         with:
           working_directory: certsuite
           make-command: 'install'

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -13,6 +13,8 @@ env:
   COLLECTOR_IMAGE_NAME: redhat-best-practices-for-k8s/collector
   COLLECTOR_IMAGE_TAG: unstable
   COLLECTOR_IMAGE_NAME_LEGACY: testnetworkfunction/collector
+  CERTSUITE_IMAGE_NAME: redhat-best-practices-for-k8s/certsuite
+  CERTSUITE_IMAGE_TAG: latest
 jobs:
   lint:
     name: Run Linter and Vet
@@ -254,7 +256,7 @@ jobs:
           docker run --rm --network host \
             -v $CERTSUITE_CONFIG_DIR:/usr/certsuite/config:Z \
             -v $CERTSUITE_OUTPUT_DIR:/usr/certsuite/output:Z \
-            ${REGISTRY_LOCAL}/${CERTSUITE_IMAGE_NAME}:${CERTSUITE_IMAGE_TAG} \
+            ${REGISTRY}/${CERTSUITE_IMAGE_NAME}:${CERTSUITE_IMAGE_TAG} \
             certsuite run \
             --output-dir=/usr/certsuite/output \
             --preflight-dockerconfig=/usr/certsuite/config/dockerconfig \

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -227,7 +227,7 @@ jobs:
           mkdir -p $CERTSUITE_CONFIG_DIR $CERTSUITE_OUTPUT_DIR
           cp /home/runner/.kube/config $CERTSUITE_CONFIG_DIR/kubeconfig
           cp /home/runner/.docker/config $CERTSUITE_CONFIG_DIR/dockerconfig
-          cp config/*.yml $CERTSUITE_CONFIG_DIR
+          cp certsuite/config/*.yml $CERTSUITE_CONFIG_DIR
         shell: bash
 
       - name: Get Collector's CI credentials

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -186,18 +186,18 @@ jobs:
 
       # needed by depends-on-action
       - name: Set up Go 1.23
-        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32  # v5.0.2
         with:
           go-version: 1.23.1
 
       # Perform smoke tests using a Certsuite container.
       - name: Check out code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
         with:
           ref: ${{ github.sha }}
 
       - name: Check out `certsuite`
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
         with:
           repository: redhat-best-practices-for-k8s/certsuite
           path: certsuite
@@ -209,7 +209,7 @@ jobs:
           make-command: 'install'
 
       - name: Extract dependent Pull Requests
-        uses: depends-on/depends-on-action@9e8a61fce18b15281e831f1bba0e14c71d1e1f46 # main
+        uses: depends-on/depends-on-action@9e8a61fce18b15281e831f1bba0e14c71d1e1f46  # main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -252,6 +252,9 @@ jobs:
             -e '/partnerName/s/""/"${{ env.COLLECTOR_CIUSER }}"/g' \
             -e '/collectorAppPassword/s/""/"${{ env.COLLECTOR_CIPASSWORD }}"/g' \
             $CERTSUITE_CONFIG_DIR/certsuite_config.yml
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
       - name: 'Test: Run Smoke Tests in a Certsuite container with the certsuite command'
         run: |

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -274,6 +274,7 @@ jobs:
             --label-filter="${SMOKE_TESTS_LABELS_FILTER}"
 
       - name: Run sanity check on collector
+        id: collector_sanity_check
         uses: ./.github/actions/run-sanity-check
         with:
           collector_username: ${COLLECTOR_CIUSER}

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -14,7 +14,6 @@ env:
   COLLECTOR_IMAGE_TAG: unstable
   COLLECTOR_IMAGE_NAME_LEGACY: testnetworkfunction/collector
   CERTSUITE_IMAGE_NAME: redhat-best-practices-for-k8s/certsuite
-  CERTSUITE_IMAGE_TAG: latest
   CERTSUITE_CONFIG_DIR: /tmp/certsuite/config
   CERTSUITE_OUTPUT_DIR: /tmp/certsuite/output
   SMOKE_TESTS_LABELS_FILTER: all
@@ -173,6 +172,9 @@ jobs:
   sanity-check:
     name: Run Collector's sanity check
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        certsuite_img_tag: [unstable, latest]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'
@@ -184,12 +186,6 @@ jobs:
           mkdir -p /home/runner/.docker
           touch ${PFLT_DOCKERCONFIG}
           echo '{ "auths": {} }' >> ${PFLT_DOCKERCONFIG}
-
-      # needed by depends-on-action
-      - name: Set up Go 1.23
-        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32  # v5.0.2
-        with:
-          go-version: 1.23.1
 
       # Perform smoke tests using a Certsuite container.
       - name: Check out code
@@ -208,11 +204,6 @@ jobs:
         with:
           working_directory: certsuite
           make-command: 'install'
-
-      - name: Extract dependent Pull Requests
-        uses: depends-on/depends-on-action@9e8a61fce18b15281e831f1bba0e14c71d1e1f46  # main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       # Clean up unused container image layers. We need to filter out a possible error return code
       # from docker with "|| true" as some images might still be used by running kind containers and
@@ -233,7 +224,7 @@ jobs:
 
       - name: Get Collector's CI credentials
         run: |
-          echo "collector_ciuser=ciuser_${{ github.run_id }}" >> $GITHUB_OUTPUT
+          echo "collector_ciuser=ciuser_${{ matrix.certsuite_img_tag }}_${{ github.run_id }}" >> $GITHUB_OUTPUT
           echo "collector_cipassword=cipassword" >> $GITHUB_OUTPUT
         id: set_collector_ci_creds
 
@@ -257,12 +248,12 @@ jobs:
       # - name: Setup tmate session
       #   uses: mxschmitt/action-tmate@v3
 
-      - name: 'Test: Run Smoke Tests in a Certsuite container with the certsuite command'
+      - name: 'Run Smoke Tests in a Certsuite unstable container with the certsuite command'
         run: |
           docker run --rm --network host \
             -v $CERTSUITE_CONFIG_DIR:/usr/certsuite/config:Z \
             -v $CERTSUITE_OUTPUT_DIR:/usr/certsuite/output:Z \
-            ${REGISTRY}/${CERTSUITE_IMAGE_NAME}:${CERTSUITE_IMAGE_TAG} \
+            ${REGISTRY}/${CERTSUITE_IMAGE_NAME}:${{ matrix.certsuite_img_tag }} \
             certsuite run \
             --output-dir=/usr/certsuite/output \
             --preflight-dockerconfig=/usr/certsuite/config/dockerconfig \
@@ -279,12 +270,3 @@ jobs:
         with:
           collector_username: ${COLLECTOR_CIUSER}
           collector_password: ${COLLECTOR_CIPASSWORD}
-        continue-on-error: true
-
-      - name: Send chat msg to dev team if collector's sanity check failed.
-        if: ${{ steps.collector_sanity_check.outcome == 'failure' }}
-        uses: ./certsuite/.github/actions/slack-webhook-sender
-        with:
-          working_directory: certsuite
-          message: 'Collector sanity check has failed'
-          slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -17,6 +17,7 @@ env:
   CERTSUITE_IMAGE_TAG: latest
   CERTSUITE_CONFIG_DIR: /tmp/certsuite/config
   CERTSUITE_OUTPUT_DIR: /tmp/certsuite/output
+  SMOKE_TESTS_LABELS_FILTER: all
 jobs:
   lint:
     name: Run Linter and Vet
@@ -253,8 +254,8 @@ jobs:
             -e '/collectorAppPassword/s/""/"${{ env.COLLECTOR_CIPASSWORD }}"/g' \
             $CERTSUITE_CONFIG_DIR/certsuite_config.yml
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3
 
       - name: 'Test: Run Smoke Tests in a Certsuite container with the certsuite command'
         run: |


### PR DESCRIPTION
Instead of running collector's sanity check in the `certsuite` repo, it will be ran in the collector's repo. The collector's Sanity check will run for every open PR using both unstable and latest certsuite images.

In addition, an alert will be sent to the slack channel for every failure in the daily "Perfrom a GET request to collector" workflow - in order to inform if the collector's VM is down.