### PR TITLE
Fix slack alert when curl collector fails

### DIFF
--- a/.github/workflows/curl-collector.yaml
+++ b/.github/workflows/curl-collector.yaml
@@ -14,9 +14,17 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'Perform a GET request to collector'
+        id: collector_sanity_check
         run: |
           curl $ENDPOINT || exit $?
+        continue-on-error: true
 
+      - name: Check out `certsuite`
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
+        with:
+          repository: redhat-best-practices-for-k8s/certsuite
+          path: certsuite
+      
       - name: Send chat msg to dev team if collector's GET request failed.
         if: ${{ steps.collector_sanity_check.outcome == 'failure' }}
         uses: ./certsuite/.github/actions/slack-webhook-sender

--- a/.github/workflows/curl-collector.yaml
+++ b/.github/workflows/curl-collector.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           repository: redhat-best-practices-for-k8s/certsuite
           path: certsuite
-      
+
       - name: Send chat msg to dev team if collector's GET request failed.
         if: ${{ steps.collector_sanity_check.outcome == 'failure' }}
         uses: ./certsuite/.github/actions/slack-webhook-sender


### PR DESCRIPTION
This PR will allow the workflow continue running when curl on the collector fails, in order to send a msg to the slack channel in next steps.
Also a check out to the certsuite repo that was missing was added.