### PR TITLE
Fail curl collector workflow when performing get on collector has failed

### DIFF
--- a/.github/workflows/curl-collector.yaml
+++ b/.github/workflows/curl-collector.yaml
@@ -18,7 +18,6 @@ jobs:
         id: collector_sanity_check
         run: |
           curl $ENDPOINT || exit $?
-        continue-on-error: true
 
       - name: Check out `certsuite`
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
@@ -27,9 +26,8 @@ jobs:
           path: certsuite
 
       - name: Send chat msg to dev team if collector's GET request failed.
-        if: ${{ steps.collector_sanity_check.outcome == 'failure' }}
+        if: ${{ failure() }}
         uses: ./certsuite/.github/actions/slack-webhook-sender
         with:
-          working_directory: certsuite
           message: 'Collector GET request has failed'
           slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'


### PR DESCRIPTION
As for now when the get request of the collector fails, a slack msg in sent to cert-and-platform-dev-team channel, but the job it self does not fail.
This PR will make the job fail as well.