### PR TITLE
Checkout certsuite when collector curl has failed

### DIFF
--- a/.github/workflows/curl-collector.yaml
+++ b/.github/workflows/curl-collector.yaml
@@ -20,6 +20,7 @@ jobs:
           curl $ENDPOINT || exit $?
 
       - name: Check out `certsuite`
+        if: ${{ failure() }}
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
         with:
           repository: redhat-best-practices-for-k8s/certsuite


### PR DESCRIPTION
As for now the "checkout certsuite" step is skipped when collector curl fails in the "Get from collector" workflow. 
This PR attempts to avoid skipping that step.