### PR TITLE
Add SKIP_PRELOAD_IMAGES env var

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -17,6 +17,7 @@ env:
   CERTSUITE_CONFIG_DIR: /tmp/certsuite/config
   CERTSUITE_OUTPUT_DIR: /tmp/certsuite/output
   SMOKE_TESTS_LABELS_FILTER: all
+  SKIP_PRELOAD_IMAGES: true
 jobs:
   lint:
     name: Run Linter and Vet


### PR DESCRIPTION
Prevents the sanity check from having to preload the images into KIND prior to running the sanity check.