### PR TITLE
Disabled slack alert msg when collector get fails.

### DIFF
--- a/.github/workflows/curl-collector.yaml
+++ b/.github/workflows/curl-collector.yaml
@@ -26,9 +26,9 @@ jobs:
           repository: redhat-best-practices-for-k8s/certsuite
           path: certsuite
 
-      # - name: Send chat msg to dev team if collector's GET request failed.
-      #   if: ${{ failure() }}
-      #   uses: ./certsuite/.github/actions/slack-webhook-sender
-      #   with:
-      #     message: 'Collector GET request has failed'
-      #     slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'
+# - name: Send chat msg to dev team if collector's GET request failed.
+#   if: ${{ failure() }}
+#   uses: ./certsuite/.github/actions/slack-webhook-sender
+#   with:
+#     message: 'Collector GET request has failed'
+#     slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'

--- a/.github/workflows/curl-collector.yaml
+++ b/.github/workflows/curl-collector.yaml
@@ -26,9 +26,9 @@ jobs:
           repository: redhat-best-practices-for-k8s/certsuite
           path: certsuite
 
-      - name: Send chat msg to dev team if collector's GET request failed.
-        if: ${{ failure() }}
-        uses: ./certsuite/.github/actions/slack-webhook-sender
-        with:
-          message: 'Collector GET request has failed'
-          slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'
+      # - name: Send chat msg to dev team if collector's GET request failed.
+      #   if: ${{ failure() }}
+      #   uses: ./certsuite/.github/actions/slack-webhook-sender
+      #   with:
+      #     message: 'Collector GET request has failed'
+      #     slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'


### PR DESCRIPTION
Just disabled the slack alert. The workflow is still running, but, while we investigate the root cause of the failures, the result of this workflow must be checked manually in the Actions log page: https://github.com/redhat-best-practices-for-k8s/collector/actions/workflows/curl-collector.yaml