### PR TITLE
Update GolangCI-lint to v1.63.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ GIT_COMMIT=$(shell scripts/create-version-files.sh)
 GIT_RELEASE=$(shell scripts/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell scripts/get-git-previous-release.sh)
 BASH_SCRIPTS=$(shell find . -name "*.sh" -not -path "./.git/*")
-GOLANGCI_VERSION=v1.63.3
+GOLANGCI_VERSION=v1.63.4
 LINKER_TNF_RELEASE_FLAGS=-X github.com/redhat-best-practices-for-k8s/certsuite/certsuite.GitCommit=${GIT_COMMIT}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/redhat-best-practices-for-k8s/certsuite/certsuite.GitRelease=${GIT_RELEASE}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/redhat-best-practices-for-k8s/certsuite/certsuite.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2705