### PR TITLE
POC: Quick-k8s for test environment

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -200,11 +200,8 @@ jobs:
           repository: redhat-best-practices-for-k8s/certsuite
           path: certsuite
 
-      - name: Setup partner cluster
-        uses: ./certsuite/.github/actions/setup-partner-cluster
-        with:
-          working_directory: certsuite
-          make-command: 'install'
+      - name: Set up k8s cluster
+        uses: palmsoftware/quick-k8s@v0.0.21
 
       # Clean up unused container image layers. We need to filter out a possible error return code
       # from docker with "|| true" as some images might still be used by running kind containers and
@@ -245,9 +242,6 @@ jobs:
             -e '/partnerName/s/""/"${{ env.COLLECTOR_CIUSER }}"/g' \
             -e '/collectorAppPassword/s/""/"${{ env.COLLECTOR_CIPASSWORD }}"/g' \
             $CERTSUITE_CONFIG_DIR/certsuite_config.yml
-
-      # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
 
       - name: 'Run Smoke Tests in a Certsuite unstable container with the certsuite command'
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,11 +18,6 @@ linters-settings:
       - whyNoLint
   gocyclo:
     min-complexity: 15
-  mnd:
-    settings:
-      mnd:
-        # do not include the "operation" and "assign"
-        checks: argument,case,condition,return
   govet:
     settings:
       printf:
@@ -33,10 +28,7 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
   lll:
     line-length: 250
-  maligned:
-    suggest-new: true
   nolintlint:
-    allow-leading-space: false # disallow leading spaces. A space means the //nolint comment shows in `godoc` output.
     allow-unused: false # report any unused nolint directives
     require-explanation: false # do not require an explanation for nolint directives
     require-specific: true # require nolint directives to be specific about which linter is being skipped
@@ -111,11 +103,3 @@ issues:
         - gocritic
       text: "unnecessaryDefer:"
     # Ignore static strings in tests
-
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.64.x # use the fixed version to not introduce new linters unexpectedly
-  prepare:
-    - echo "here I can run custom commands, but no preparation needed for this repo"


### PR DESCRIPTION
Avoid using the partner cluster setup, just use `quick-k8s`.