### PR TITLE
Add retries for Ansible

### DIFF
--- a/.github/workflows/collector-image.yaml
+++ b/.github/workflows/collector-image.yaml
@@ -99,12 +99,15 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.COLLECTOR_KEYPAIR }}
 
-      # run ansible deployment to deploy the new image to the cluster
       - name: Deploy the newly built image to the cluster
-        run: |
-          ANSIBLE_HOST_KEY_CHECKING=false \
-          COLLECTOR_VERSION=${{ env.COLLECTOR_VERSION }} \
-          ansible-playbook -i playbooks/inventory.ini playbooks/start-collector.yaml
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          command: |
+            ANSIBLE_HOST_KEY_CHECKING=false \
+            COLLECTOR_VERSION=${{ env.COLLECTOR_VERSION }} \
+            ansible-playbook -i playbooks/inventory.ini playbooks/start-collector.yaml
 
   test-and-push-collector-image-legacy:
     name: 'Test and push the collector image (legacy)'


### PR DESCRIPTION
This pull request updates the deployment process in the GitHub Actions workflow for the collector image. The primary change introduces a retry mechanism to improve reliability when deploying the newly built image to the cluster.

### Deployment process improvements:
* [`.github/workflows/collector-image.yaml`](diffhunk://#diff-ccf6e5bd3be5330bc56b3109711cd6e2e766d4600f436bfec74999119d0f1aedL102-R107): Replaced the direct execution of the Ansible deployment command with the `nick-fields/retry` action (v3.0.2). This adds retry logic with a maximum of 3 attempts and a timeout of 90 minutes to ensure robustness during deployment.