### PR TITLE
Linter fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,6 +61,10 @@ linters:
       require-explanation: false
       require-specific: true
       allow-unused: false
+    revive:
+      rules:
+        - name: var-naming
+          disabled: true
   exclusions:
     generated: lax
     presets:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ DB_URL = database-collectordb-1hykanj2mxdh.cn9luyhgvfkp.us-east-1.rds.amazonaws.
 S3_BUCKET_NAME?=cnf-suite-claims
 S3_BUCKET_REGION?=us-east-1
 
-.PHONY: all clean test
+.PHONY: all clean test tool-precheck
 
 # Build and run unit tests
 test:
@@ -49,8 +49,21 @@ vet:
 build:
 	go build -ldflags "${LINKER_TNF_RELEASE_FLAGS}" ${COMMON_GO_ARGS} -o collector
 
+# Checks that all required linting tools are installed
+tool-precheck:
+	@echo "Checking for required linting tools..."
+	@which checkmake > /dev/null || (echo "❌ checkmake not found. Please install checkmake" && exit 1)
+	@which golangci-lint > /dev/null || (echo "❌ golangci-lint not found. Please install golangci-lint" && exit 1)
+	@which hadolint > /dev/null || (echo "❌ hadolint not found. Please install hadolint" && exit 1)
+	@which shfmt > /dev/null || (echo "❌ shfmt not found. Please install shfmt" && exit 1)
+	@which typos > /dev/null || (echo "❌ typos not found. Please install typos-cli" && exit 1)
+	@which markdownlint > /dev/null || (echo "❌ markdownlint not found. Please install markdownlint-cli" && exit 1)
+	@which yamllint > /dev/null || (echo "❌ yamllint not found. Please install yamllint" && exit 1)
+	@which shellcheck > /dev/null || (echo "❌ shellcheck not found. Please install shellcheck" && exit 1)
+	@echo "✅ All required linting tools are installed"
+
 # Runs configured linters
-lint:
+lint: tool-precheck
 	checkmake --config=.checkmake Makefile
 	golangci-lint run --timeout 10m0s
 	hadolint Dockerfile
@@ -60,11 +73,18 @@ lint:
 	yamllint --no-warnings .
 	shellcheck --format=gcc ${BASH_SCRIPTS}
 
+# Install linting tools on macOS using Homebrew
+# For other platforms, use your package manager (apt, yum, pacman, etc.)
 install-mac-brew-tools:
 	brew install \
 		checkmake \
 		golangci-lint \
-		hadolint
+		hadolint \
+		shfmt \
+		typos-cli \
+		markdownlint-cli \
+		yamllint \
+		shellcheck
 
 # Pulls collector image from quay.io
 pull-image-collector:


### PR DESCRIPTION
This pull request introduces updates to the linting configuration and build process, focusing on improving linting tool management and configuration. The key changes include adding a precheck for required linting tools, updating the linting configuration in `.golangci.yml`, and enhancing the `Makefile` with new targets and dependencies.

### Linting Configuration Updates:
* [`.golangci.yml`](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9R64-R67): Added a configuration to disable the `var-naming` rule in the `revive` linter. This provides more flexibility in variable naming conventions.

### Build Process Enhancements:
* `Makefile`:
  - Added a new `tool-precheck` target to verify the installation of required linting tools (`checkmake`, `golangci-lint`, `hadolint`, `shfmt`, `typos-cli`, `markdownlint-cli`, `yamllint`, and `shellcheck`) before running linting tasks.
  - Updated the `lint` target to depend on `tool-precheck`, ensuring all necessary tools are installed before linting.
  - Introduced the `install-mac-brew-tools` target to simplify the installation of linting tools on macOS using Homebrew.

These changes streamline the linting process, reduce potential errors caused by missing tools, and improve the overall developer experience.